### PR TITLE
Ensure SAM2 binary masks match GT shapes

### DIFF
--- a/finetune_classic.py
+++ b/finetune_classic.py
@@ -193,7 +193,10 @@ class SAM2ClassicTrainer:
                         )
                         
                         # Calcular loss
-                        pred_masks = outputs.pred_masks.squeeze(1)
+                        pred_masks = (
+                            outputs.pred_masks.squeeze(0)
+                            .max(dim=0, keepdim=True)[0]
+                        )
                         
                         # Asegurar que las dimensiones coincidan
                         if pred_masks.shape[-2:] != gt_masks.shape[-2:]:
@@ -319,7 +322,10 @@ class SAM2ClassicTrainer:
                         )
                         
                         # Calcular métricas
-                        pred_masks = outputs.pred_masks.squeeze(1)
+                        pred_masks = (
+                            outputs.pred_masks.squeeze(0)
+                            .max(dim=0, keepdim=True)[0]
+                        )
                         
                         # Asegurar que las dimensiones coincidan
                         if pred_masks.shape[-2:] != gt_masks.shape[-2:]:

--- a/finetune_lora.py
+++ b/finetune_lora.py
@@ -167,14 +167,20 @@ class SAM2LoRATrainer:
                         )
                         
                         # Calcular loss
-                        pred_masks = outputs.pred_masks.squeeze(1)
-                        loss, bce_loss, dice_loss = self.compute_loss(pred_masks, gt_masks)
-                        
+                        pred_masks = (
+                            outputs.pred_masks.squeeze(0)
+                            .max(dim=0, keepdim=True)[0]
+                        )
+                        loss, bce_loss, dice_loss = self.compute_loss(
+                            pred_masks,
+                            gt_masks.unsqueeze(0)
+                        )
+
                         # Calcular IoU
                         with torch.no_grad():
                             iou = calculate_iou(
-                                torch.sigmoid(pred_masks), 
-                                gt_masks,
+                                torch.sigmoid(pred_masks),
+                                gt_masks.unsqueeze(0),
                                 threshold=0.5
                             )
                     
@@ -239,11 +245,17 @@ class SAM2LoRATrainer:
                         )
                         
                         # Calcular métricas
-                        pred_masks = outputs.pred_masks.squeeze(1)
-                        loss, _, _ = self.compute_loss(pred_masks, gt_masks)
+                        pred_masks = (
+                            outputs.pred_masks.squeeze(0)
+                            .max(dim=0, keepdim=True)[0]
+                        )
+                        loss, _, _ = self.compute_loss(
+                            pred_masks,
+                            gt_masks.unsqueeze(0)
+                        )
                         iou = calculate_iou(
-                            torch.sigmoid(pred_masks), 
-                            gt_masks,
+                            torch.sigmoid(pred_masks),
+                            gt_masks.unsqueeze(0),
                             threshold=0.5
                         )
                         

--- a/finetune_qlora.py
+++ b/finetune_qlora.py
@@ -196,17 +196,23 @@ class SAM2QLoRATrainer:
                         )
                         
                         # Calcular loss
-                        pred_masks = outputs.pred_masks.squeeze(1)
-                        loss, bce_loss, dice_loss = self.compute_loss(pred_masks, gt_masks)
-                        
+                        pred_masks = (
+                            outputs.pred_masks.squeeze(0)
+                            .max(dim=0, keepdim=True)[0]
+                        )
+                        loss, bce_loss, dice_loss = self.compute_loss(
+                            pred_masks,
+                            gt_masks.unsqueeze(0)
+                        )
+
                         # Escalado del loss para quantización
                         loss = loss / batch_size
-                        
+
                         # Calcular IoU
                         with torch.no_grad():
                             iou = calculate_iou(
-                                torch.sigmoid(pred_masks), 
-                                gt_masks,
+                                torch.sigmoid(pred_masks),
+                                gt_masks.unsqueeze(0),
                                 threshold=0.5
                             )
                     
@@ -279,11 +285,17 @@ class SAM2QLoRATrainer:
                         )
                         
                         # Calcular métricas
-                        pred_masks = outputs.pred_masks.squeeze(1)
-                        loss, _, _ = self.compute_loss(pred_masks, gt_masks)
+                        pred_masks = (
+                            outputs.pred_masks.squeeze(0)
+                            .max(dim=0, keepdim=True)[0]
+                        )
+                        loss, _, _ = self.compute_loss(
+                            pred_masks,
+                            gt_masks.unsqueeze(0)
+                        )
                         iou = calculate_iou(
-                            torch.sigmoid(pred_masks), 
-                            gt_masks,
+                            torch.sigmoid(pred_masks),
+                            gt_masks.unsqueeze(0),
                             threshold=0.5
                         )
                         

--- a/inference.py
+++ b/inference.py
@@ -101,8 +101,11 @@ class SAM2Inferencer:
             outputs = self.model(**inputs)
         
         # Procesar salida
-        pred_masks = outputs.pred_masks.squeeze().cpu().numpy()
-        pred_masks = torch.sigmoid(torch.tensor(pred_masks)).numpy()
+        pred_masks = (
+            outputs.pred_masks.squeeze(0)
+            .max(dim=0, keepdim=True)[0]
+        )
+        pred_masks = torch.sigmoid(pred_masks).squeeze().cpu().numpy()
         
         return {
             'image': np.array(image),


### PR DESCRIPTION
## Summary
- consolidate multi-mask outputs into single binary mask
- align ground-truth mask shapes during loss and metric calculations

## Testing
- `pytest -q` *(fails: No module named 'torch')*
- `pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu` *(fails: No matching distribution found for torch)*

------
https://chatgpt.com/codex/tasks/task_e_68b5cd92482c832087cf0559668d1326